### PR TITLE
Update GitWitchSpec.js

### DIFF
--- a/spec/GitWitchSpec.js
+++ b/spec/GitWitchSpec.js
@@ -10,9 +10,9 @@ describe("GitWitch", () => {
     this.response = "response";
     this.output = "output";
 
-    spyOn(this.parser, "parse").andReturn(this.command);
-    spyOn(this.runner, "run").andReturn(Promise.resolve(this.response));
-    spyOn(this.formatter, "format").andReturn(this.output);
+    spyOn(this.parser, "parse").and.returnValue(this.command);
+    spyOn(this.runner, "run").and.returnValue(Promise.resolve(this.response));
+    spyOn(this.formatter, "format").and.returnValue(this.output);
 
     this.witch = new GitWitch({
       parser: this.parser,


### PR DESCRIPTION
New syntax for `spyOn(obj, method).and.returnValue('foo');`
Src: [Jasmine Docs](https://jasmine.github.io/2.0/introduction.html#section-Spies:_<code>and.returnValue</code>)